### PR TITLE
Application config

### DIFF
--- a/tadow_api/config.py
+++ b/tadow_api/config.py
@@ -1,0 +1,40 @@
+from typing import Optional
+
+
+_default_config: Optional["Config"] = None
+
+
+def set_default_config(config: "Config") -> None:
+    """
+    Method used to set default config for global usage.
+    :param config: Config instance
+    """
+    global _default_config
+    _default_config = config
+
+
+def get_default_config() -> "Config":
+    """
+    Return custom instance of config or default.
+    :return:
+    """
+    return _default_config or Config()
+
+
+class Config:
+    """@DynamicAttrs"""
+
+    def __init__(
+        self,
+        debug: bool = False,
+        default_content_type: str = "application/json",
+        default_encoding: str = "utf-8",
+        **extra_fields,
+    ) -> None:
+        self.debug = debug
+        self.default_content_type = default_content_type
+        self.default_encoding = default_encoding
+
+        # Add custom fields to object
+        for field, value in extra_fields.items():
+            setattr(self, field, value)

--- a/tadow_api/content_parsers.py
+++ b/tadow_api/content_parsers.py
@@ -5,6 +5,8 @@ import xmltodict
 from abc import ABC, abstractmethod
 from typing import Type
 
+from tadow_api.config import get_default_config
+
 
 class BaseParser(ABC):
     @classmethod
@@ -51,7 +53,7 @@ class ApplicationJsonParser(BaseParser):
     @classmethod
     def parse_request_data(cls, raw_data: bytes) -> dict:
         try:
-            return json.loads(raw_data.decode("utf-8"))
+            return json.loads(raw_data.decode(get_default_config().default_encoding))
         except json.JSONDecodeError:
             from tadow_api.exceptions import HttpException
 
@@ -59,7 +61,7 @@ class ApplicationJsonParser(BaseParser):
 
     @classmethod
     def parse_response_data(cls, raw_data: dict) -> bytes:
-        return json.dumps(raw_data).encode("utf-8")
+        return json.dumps(raw_data).encode(get_default_config().default_encoding)
 
 
 @ContentParser.register_parser(content_type="application/xml")
@@ -67,7 +69,9 @@ class ApplicationXMLParser(BaseParser):
     @classmethod
     def parse_request_data(cls, raw_data: bytes) -> dict:
         try:
-            return xmltodict.parse(raw_data, encoding="utf-8")
+            return xmltodict.parse(
+                raw_data, encoding=get_default_config().default_encoding
+            )
         except xml.parsers.expat.ExpatError:
             from tadow_api.exceptions import HttpException
 
@@ -77,4 +81,6 @@ class ApplicationXMLParser(BaseParser):
     def parse_response_data(cls, raw_data: dict) -> bytes:
         from dicttoxml import dicttoxml
 
-        return dicttoxml(raw_data, encoding="utf-8", return_bytes=True)
+        return dicttoxml(
+            raw_data, encoding=get_default_config().default_encoding, return_bytes=True
+        )

--- a/tadow_api/responses.py
+++ b/tadow_api/responses.py
@@ -1,6 +1,8 @@
 from typing import Any, TYPE_CHECKING, Type
 
 from pydantic import BaseModel
+
+from tadow_api.config import get_default_config
 from tadow_api.content_parsers import ContentParser
 
 if TYPE_CHECKING:
@@ -14,13 +16,13 @@ class HTTPResponse:
     def __init__(
         self,
         status_code: int,
-        content_type: str,
         raw_data: _SIMPLE_TYPES,
         headers: list[tuple[str, str]],
+        content_type: str | None = None,
     ):
         self.status_code = status_code
         self.raw_data = raw_data
-        self.content_type = content_type
+        self.content_type = content_type or get_default_config().default_content_type
         self.headers = headers
 
     async def send_response(self, send):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,20 @@
+from tadow_api.config import Config, set_default_config, get_default_config
+
+
+def test_config():
+    config = Config(
+        debug=True,  # Default field,
+        custom_field="Test",
+    )
+
+    assert config.debug
+    assert hasattr(config, "custom_field")
+    assert getattr(config, "custom_field") == "Test"
+
+
+def test_setting_config():
+    default_config = get_default_config()
+    assert default_config.debug is False
+
+    set_default_config(Config(debug=True))
+    assert get_default_config().debug


### PR DESCRIPTION
This PR adds a base app config class, which allows the configuration of the following settings:

- debug
- default_content_type
- default_encoding
- custom user fields (passed as kwargs to Config class)

With new features, the base config will be extended by new fields.